### PR TITLE
Replace `lvsfunc.kernels` with `vskernels

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ packaging==21.0
 pycodestyle==2.7.0
 typing-extensions>=3.10.0.2
 VapourSynth>=57
+vs-kernels>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 VapourSynth>=57
 lvsfunc>=0.3.11
 vsutil>=0.6.0
+vs-kernels>=1.0.0

--- a/stgfunc/deband.py
+++ b/stgfunc/deband.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import vapoursynth as vs
 from itertools import cycle
-from lvsfunc.kernels import Catrom, Lanczos
+from vskernels import Catrom, Lanczos
 from typing import Tuple, Any, Dict, SupportsFloat
 from debandshit.debanders import f3kbilateral, dumb3kdb
 from vsutil import depth, get_y, get_w, join, get_depth, iterate, Dither

--- a/stgfunc/transitions.py
+++ b/stgfunc/transitions.py
@@ -8,7 +8,7 @@ from enum import Enum, IntEnum
 from vsutil import insert_clip
 from fractions import Fraction
 from lvsfunc.types import Range
-from lvsfunc.kernels import Kernel, Catrom
+from vskernels import Kernel, Catrom
 from typing import NamedTuple, Union, Tuple, Sequence
 from lvsfunc.util import clamp_values, normalize_ranges
 

--- a/stgfunc/tweaking.py
+++ b/stgfunc/tweaking.py
@@ -7,7 +7,7 @@ from itertools import cycle
 from math import pi, sin, cos, degrees
 from lvsfunc.util import normalize_ranges
 from lvsfunc.types import VSFunction, Range
-from lvsfunc.kernels import Catrom, Point, BSpline
+from vskernels import Catrom, Point, BSpline
 from typing import Tuple, Sequence, SupportsFloat, Dict, Any, NamedTuple, List
 from vsutil import fallback, scale_value, get_depth, insert_clip, get_neutral_value, get_peak_value, get_subsampling
 

--- a/stgfunc/utils.py
+++ b/stgfunc/utils.py
@@ -12,7 +12,7 @@ from math import ceil, floor
 from fractions import Fraction
 from lvsfunc.types import Range
 from lvsfunc.util import get_prop
-from lvsfunc.kernels import Point
+from vskernels import Point
 from vsutil import depth as vdepth, get_depth
 from typing import Tuple, Union, List, Sequence, Dict, Any, TypeVar, Iterator, Iterable, SupportsFloat
 


### PR DESCRIPTION
`kernels` has split off from `lvsfunc` and is now its own package.
https://vskernels.encode.moe/en/latest/